### PR TITLE
Update docker-compose from node-12 to node-16

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3.7"
 services: 
     dev:
-        image: "node:12.15-alpine"
+        image: "node:16.20.2-alpine"
         working_dir: "/srv"
         command: "npm run develop"
         tty: true


### PR DESCRIPTION
# Modifica eseguita: 
- Dopo aggiornamento con Enrico Emanuele, ho allineato il docker.compose in quanto l'image era ancora a node-12 mentre come ambiente utilizziamo node-16.  
- Testato il progetto per vedere che sia tutto corretto
 
# Attention: 
- Ipotizzare e preventivare di passare da Gridsome che supporta al massimo node-16 ( il prox ad andare out the box ) ad un framework come Astro ( fattibile in Vue, React, Svelte ) , Next ( per nuovo stack sono in React ) o Nuxt ( stesso stack in Vue )

